### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - wget
+      - pkg-config  
+
+before_install:
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.4.5/bazel_0.4.5-linux-x86_64.deb
+  - sha256sum -c tools/bazel_0.4.5-linux-x86_64.deb.sha256
+  - sudo dpkg -i bazel_0.4.5-linux-x86_64.deb
+
+script:
+  - bazel build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# sjchat
+
+[![Build Status](https://travis-ci.org/sjchat/sjchat.svg?branch=master)](https://travis-ci.org/sjchat/sjchat)

--- a/tools/bazel_0.4.5-linux-x86_64.deb.sha256
+++ b/tools/bazel_0.4.5-linux-x86_64.deb.sha256
@@ -1,0 +1,2 @@
+b494d0a413e4703b6cd5312403bea4d92246d6425b3be68c9bfbeb8cc4db8a55  bazel_0.4.5-linux-x86_64.deb
+


### PR DESCRIPTION
### Issues: #5 

### Test Plan
Go to travis.org, make sure travis is running for the project.

### Description
Adds a .travis.yml that instructs travis-ci to install bazel and then run `bazel build` Also adds a build status icon to the readme.
This implements continous integration which makes sure the build always passes after changes are pushed.