### PR TITLE
Added flag to build that will make the build stop on an error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+set -e
 echo "Build started"
 
 echo "Building user service"


### PR DESCRIPTION
### Issues:  #36

### Test Plan
Added a non existing command to build.sh and runned build.sh. It failed.

### Description
Fixed issue #36. Added a flag that will make build.sh fail on an error.