### PR TITLE
added mongo database as a docker container

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -33,6 +33,17 @@ services:
       - "50052:50052"
     networks:
       - webnet
+  
+  database:
+    image: mongo:3.4.4
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+    ports:
+      - "27017:27017"
+    networks:
+      - webnet
 
   user-service:
     image: sjchat-user-service

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -35,6 +35,17 @@ services:
     networks:
       - webnet
 
+  database:
+    image: mongo:3.4.4
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+    ports:
+      - "27017:27017"
+    networks:
+      - webnet
+
   user-service:
     image: sawny/sjchat-user-service:stable
     deploy:

--- a/docker-compose-staging.yaml
+++ b/docker-compose-staging.yaml
@@ -35,6 +35,17 @@ services:
     networks:
       - webnet
 
+  database:
+    image: mongo:3.4.4
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+    ports:
+      - "27017:27017"
+    networks:
+      - webnet
+
   user-service:
     image: sawny/sjchat-user-service
     deploy:


### PR DESCRIPTION
### Issues: #29

### Test Plan
I build the project (`build.sh`) and started it with `docker stack deploy -c docker-compose-local.yaml sjchat`. I also deployed everything to staging and production.

I haven't tested that the mongo server actually works, because I'm not sure how I can do that.

The mongodb server should run on host `database:27017` (like localhost:27017).

The mongo server also probably just saves the data temporarily (untill server restart / update) at the moment. We'll probably need to use something like `volumes: - "/var/run/docker.sock:/var/run/docker.sock"` to save the data between updates and server restarts.

### Description
Added a mongodb container.
