### PR TITLE
Make travis build and upload our docker images to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,18 @@ services:
 
 script:
   - ./build.sh
-  
+
+after_success:
+  if ([ "$TRAVIS_BRANCH" == "master" ] then
+    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+
+    docker build -t sjchat-message-service ./message-service
+    docker build -t sjchat-user-service ./user-service
+    docker build -t sjchat-restapi ./restapi
+    docker build -t sjchat-web-client ./client
+
+    ./tools/publish-docker-image.sh
+  fi
+
 notifications:
   email: false


### PR DESCRIPTION
### Issues: #42

This PR depends on #54 (changed dockerhub account). So #54 must be merged before this PR.

### Test Plan
Followed this guide: https://sebest.github.io/post/using-travis-ci-to-build-docker-images/

Will hopefully work.

### Description
Step one of #42. This PR will build and upload our docker images to docker hub if the build was successful and the branch was master.
