### PR TITLE
Feature/cleanup docker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ If you're stuck ask on slack for help, and update this with what went wrong and 
 
 #### ``docker stack deploy`` scares me with ``unable to pin image`` and ``unauthorized: authentication required``
 This is normal, and just a warning that the images wasn't found online so docker uses the local ones. Everything actually works
+
+#### I have run out of disk space!
+Old docker images are saved on your system. **All docker images on your system** can be removed by running cleanup-docker.sh in tools.

--- a/tools/cleanup-docker.sh
+++ b/tools/cleanup-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+read -p "DANGER: This will remove *all* docker images on your system. Are you sure? (y/n) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # Delete all containers
+    echo "Deleting containers..."
+    docker rm $(docker ps -a -q)
+    # Delete all images
+    echo "Deleting images..."
+    docker rmi $(docker images -q)
+else #
+    echo "Did nothing"
+fi


### PR DESCRIPTION
Based on PR #56 so should be merged afterwards.

### Test Plan
Run ``docker images`` before and after running the added cleanup script.

### Description
Added a script that removes all docker images on your system. This can be useful to save space, since after a while they take up a couple GB of disk space.
