### PR TITLE
hopefully fixed the travis after-success script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,7 @@ script:
   - ./build.sh
 
 after_success:
-  if ([ "$TRAVIS_BRANCH" == "master" ] then
-    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-
-    docker build -t sjchat-message-service ./message-service
-    docker build -t sjchat-user-service ./user-service
-    docker build -t sjchat-restapi ./restapi
-    docker build -t sjchat-web-client ./client
-
-    ./tools/publish-docker-image.sh
-  fi
+ - ./tools/travis-after-success.sh
 
 notifications:
   email: false

--- a/tools/travis-after-success.sh
+++ b/tools/travis-after-success.sh
@@ -1,0 +1,11 @@
+if [ "$TRAVIS_BRANCH" == "master" ]
+then
+    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+
+    docker build -t sjchat-message-service ./message-service
+    docker build -t sjchat-user-service ./user-service
+    docker build -t sjchat-restapi ./restapi
+    docker build -t sjchat-web-client ./client
+
+    ./tools/publish-docker-image.sh
+fi


### PR DESCRIPTION
### Issues: #42 and #61 

### Test Plan
Ran travis-after-success.sh locally. Hopefully it will work.

### Description
The old travis file didn't work as expected:

```
$ if ([ "$TRAVIS_BRANCH" == "master" ] then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
    docker build -t sjchat-message-service ./message-service docker build -t sjchat-user-service ./user-service docker build -t sjchat-restapi ./restapi docker build -t sjchat-web-client ./client
    ./tools/publish-docker-image.sh fi
/home/travis/.travis/job_stages: eval: line 640: syntax error: unexpected end of file
```

Hopefully this travis file will work.