### PR TITLE
Add auto-deploy to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,23 @@ You need both **maven** and **docker** to compile and run the project.
 3. You can now access the services via `localhost:8080` etc.
 4. If you want to stop developing and waste your time on other schoolwork, run `docker stack rm sjchat`.
 
-### Pushing to staging/dev
+### Manually pushing to staging/dev
 
 1. Build with `sh build.sh`
-2. Upload all images to the public docker hub with `sh tools/publish-docker-images.sh` (You will need to join the organsiation sjchat on docker hub to get access)
-3. Upload the latest docker-compose file to the manager server with `docker-machine scp docker-compose-staging.yaml sjchat-staging-mgr1:~`
+2. Upload all images to the public docker hub with `sh tools/publish-docker-images.sh` (You will need to join the organisation sjchat on docker hub to get access)
+3. Upload the latest docker-compose file to the manager server with `docker-machine scp docker-compose-staging.yaml sjchat-staging-mgr1:~` or `gcloud compute copy-files docker-compose-staging.yaml sjchat-staging-mgr1:/home/docker-user/`
 4. SSH to the manager server in the docker swarm and run 
 ```
 docker-machine ssh sjchat-staging-mgr1 "sudo docker stack deploy -c docker-compose-staging.yaml sjchat"
 ```
-
 This command probably create some downtime.
+
+### Updating staging deployment script
+1. Upload scripts to server with `gcloud compute copy-files tools/deploy-service.py tools/deploy-script.sh tools/start-deploy-service.sh root@sjchat-staging-mgr1:/home/docker-user/auto-deploy/`. Select zone 10 (europe-west-c)
+2. SSH in with `gcloud compute ssh sjchat-staging-mgr1`
+3. Move to correct folder with `cd /home/docker-user/auto-deploy/`
+4. Kill the old script with `sudo` and `jobs`/`ps`/`kill`
+5. Start the new script with `sudo sh run-deploy-service.sh`
 
 ### It doesn't work! :c
 

--- a/tools/deploy-script.sh
+++ b/tools/deploy-script.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+curl https://raw.githubusercontent.com/sjchat/sjchat/master/docker-compose-staging.yaml > docker-compose-staging.yaml
+sudo docker stack deploy -c docker-compose-staging.yaml sjchat

--- a/tools/deploy-service.py
+++ b/tools/deploy-service.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import subprocess
+ 
+password = ''
+
+def deploy():
+    subprocess.Popen(['sh', 'deploy-script.sh'])
+    
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def handleDeploy(self):
+        # Send response status code
+        self.send_response(200)
+
+        # Send headers
+        self.send_header('Content-type','text/html')
+        self.end_headers()
+
+        message = 'Deploying...'
+
+        # Write content as utf-8 data
+        self.wfile.write(bytes(message, 'utf8'))
+        deploy()
+
+
+    def handleInvalidCode(self):
+        self.send_response(401)
+        # Send headers
+        self.send_header('Content-type','text/html')
+        self.end_headers()
+
+        message = 'Invalid deploy code'
+
+        # Write content as utf-8 data
+        self.wfile.write(bytes(message, 'utf8'))
+
+
+    def do_GET(self):
+        if self.path == '/deploy' + password:
+            self.handleDeploy()
+        else:
+            self.handleInvalidCode()
+
+
+def run():
+    # Load deploy password
+    global password
+    try:
+        f = open('password',  'r')
+        password = f.read().strip()
+    except:
+        print("Error reading password file")
+        return
+
+    # Server settings
+    print('Setting up...')    
+    address = ('', 50053)
+    server = HTTPServer(address, RequestHandler)
+    server.password = password
+
+    print('Starting server...')
+    server.serve_forever()
+
+ 
+run()

--- a/tools/start-deploy-service.sh
+++ b/tools/start-deploy-service.sh
@@ -1,0 +1,1 @@
+nohup python3 deploy-service.py </dev/null >auto-deploy.log 2>&1 &

--- a/tools/travis-after-success.sh
+++ b/tools/travis-after-success.sh
@@ -8,4 +8,5 @@ then
     docker build -t sjchat-web-client ./client
 
     ./tools/publish-docker-images.sh
+    curl -s http://staging.sjchat.wallstrom.it:50053/deploy$DEPLOY_CODE
 fi


### PR DESCRIPTION
### Issues: #42 

### Test Plan
Accessed staging.sjchat.wallstrom.it:50053/deploy.
Saw that this started a successful deployment.
Travis script should work, but only way to test is to merge.

### Description
After we push to master, travis notifies a script running on the manager server which in turn updates the cluster with the newest docker images.
