### PR TITLE
Improve build times

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This command probably create some downtime.
 1. Upload scripts to server with `gcloud compute copy-files tools/deploy-service.py tools/deploy-script.sh tools/start-deploy-service.sh root@sjchat-staging-mgr1:/home/docker-user/auto-deploy/`. Select zone 10 (europe-west-c)
 2. SSH in with `gcloud compute ssh sjchat-staging-mgr1`
 3. Move to correct folder with `cd /home/docker-user/auto-deploy/`
-4. Kill the old script with `sudo` and `jobs`/`ps`/`kill`
+4. Kill the old script with `sudo` and `jobs`/`ps -e`/`kill`
 5. Start the new script with `sudo sh run-deploy-service.sh`
 
 ### It doesn't work! :c

--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,8 @@
 set -e
 echo "Build started"
 
-echo "Building database service"
-mvn -f database-service install
-
-echo "Building service general"
-mvn -f service-general install
-
-echo "Building user service"
-mvn -f user-service install
-
-echo "Building message service"
-mvn -f message-service install
-
-echo "Building rest api"
-mvn -f restapi install
-
-
+# Build all services
+mvn -T 1C install
 
 # Docker
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>com.sjchat</groupId>
+    <artifactId>main</artifactId>
+    <version>2.0</version>
+    <packaging>pom</packaging>
+    
+    <modules>
+        <module>service-general</module>
+        <module>database-service</module>
+        <module>message-service</module>
+        <module>user-service</module>
+        <module>restapi</module>
+    </modules>
+</project>


### PR DESCRIPTION
### Issues: Resolves #93 

### Test Plan
Ran and timed build.sh before and after my changes. The services start correctly in both, but now the build takes 25s instead of 50s.

### Description
Made a big maven project that includes all the smaller ones. This improves build time a lot, since a lot of time is taken by maven starting up. I also added the maven option `-T 1C` which tries to parallelize the build. I didn't notice any improvements from this, but maybe people with more cores will.
