### PR TITLE
Made it not possible to have two or more users with same username

### DIFF
--- a/database-service/src/main/java/sjchat/daos/UserDaoImpl.java
+++ b/database-service/src/main/java/sjchat/daos/UserDaoImpl.java
@@ -2,6 +2,8 @@ package sjchat.daos;
 
 import sjchat.entities.UserEntity;
 
+import javax.persistence.EntityTransaction;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 import java.util.List;
 

--- a/database-service/src/main/java/sjchat/entities/UserEntity.java
+++ b/database-service/src/main/java/sjchat/entities/UserEntity.java
@@ -1,20 +1,25 @@
 package sjchat.entities;
 
+
+import com.impetus.kundera.index.Index;
+import com.impetus.kundera.index.IndexCollection;
+
 import javax.persistence.*;
+import java.util.Random;
 
 @Entity
 @Table(name = "users")
+@IndexCollection(columns = { @Index(name="username") })//index on collection
 public class UserEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private String id;
-  @Column(name = "username")
+  @Column(name = "username", unique=true)
   private String username;
   private String password;
 
-  public UserEntity() {
-  }
+  public UserEntity() {}
 
   public UserEntity(String id, String username) {
     this.id = id;
@@ -31,6 +36,10 @@ public class UserEntity {
 
   public String getUsername() {
     return username;
+  }
+
+  public String getPassword(){
+    return password;
   }
 
   public void setUsername(String username) {

--- a/user-service/src/main/java/sjchat/users/UserService.java
+++ b/user-service/src/main/java/sjchat/users/UserService.java
@@ -19,7 +19,6 @@ class UserService extends UserServiceGrpc.UserServiceImplBase {
   @Override
   public void createUser(CreateUserRequest req, StreamObserver<CreateUserResponse> responseObserver) {
     UserEntity entity = new UserEntity(null, req.getUsername());
-    //TODO: Check that no user with this username exists (kundera should throw an exception I think?)
 
     if(dao.findByUsername(entity.getUsername()) != null){
       responseObserver.onError(new UserAlreadyExistsException());

--- a/user-service/src/main/java/sjchat/users/exceptions/UserAlreadyExistsException.java
+++ b/user-service/src/main/java/sjchat/users/exceptions/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package sjchat.users.exceptions;
+
+/**
+ * Created by jovi on 2017-05-11.
+ */
+public class UserAlreadyExistsException extends Exception {
+}


### PR DESCRIPTION
### Issues: #38

### Test Plan
Verified by testing REST endpoints

### Description
Added a call to UserDao::findByUsername() in UserService::createUser() and checked that return was null. The kundera built in solution apparently does not work with Mongodb (setting the column(unique=true). There might be trouble with concurrency, (add user after we've called findByUsername), I don't know how we would solve that however.

I'll attempt to move us to Cassandra and that should solve this issue and make the additional check in UserService redundant.