### PR TITLE
Fix/105 chat empty name

### DIFF
--- a/message-service/src/main/java/sjchat/messages/MessageService.java
+++ b/message-service/src/main/java/sjchat/messages/MessageService.java
@@ -136,6 +136,11 @@ class MessageService extends MessageServiceGrpc.MessageServiceImplBase {
 
   @Override
   public void updateChat(UpdateChatRequest req, StreamObserver<UpdateChatResponse> responseObserver) {
+    if (req.getTitle() == null || req.getTitle().length() == 0) {
+      responseObserver.onError(new Exception("Title is empty or missing"));
+      responseObserver.onCompleted();
+    }
+
     ChatEntity.Builder builder = new ChatEntity.Builder();
     builder.setId(req.getId())
             .setTitle(req.getTitle())

--- a/message-service/src/main/java/sjchat/messages/MessageService.java
+++ b/message-service/src/main/java/sjchat/messages/MessageService.java
@@ -40,32 +40,7 @@ class MessageService extends MessageServiceGrpc.MessageServiceImplBase {
 
     return ManagedChannelBuilder.forAddress(host, 50051).usePlaintext(true).build();
   }
-
-  private static Chat.Builder buildMockChat(String id) {
-    Random random = new Random();
-    Chat.Builder chatBuilder = Chat.newBuilder();
-    chatBuilder.setId("mock-id");
-    chatBuilder.setTitle("Test chat " + chatBuilder.getId());
-    return chatBuilder;
-  }
-
-  private static User.Builder buildMockUser() {
-    Random random = new Random();
-    User.Builder userBuilder = User.newBuilder();
-    userBuilder.setId("mock-id");
-    userBuilder.setUsername("user_" + userBuilder.getId());
-    return userBuilder;
-  }
-
-  private static Message.Builder buildMockMessage() {
-    Random random = new Random();
-    Message.Builder messageBuilder = Message.newBuilder();
-    messageBuilder.setId("mock-id");
-    messageBuilder.setMessage("Test message " + messageBuilder.getId());
-    messageBuilder.setSender("id");
-    return messageBuilder;
-  }
-
+  
   private void initializeMessageExchange() {
     try {
       tryInitializeMessageExchange();

--- a/message-service/src/main/java/sjchat/messages/MessageService.java
+++ b/message-service/src/main/java/sjchat/messages/MessageService.java
@@ -40,7 +40,7 @@ class MessageService extends MessageServiceGrpc.MessageServiceImplBase {
 
     return ManagedChannelBuilder.forAddress(host, 50051).usePlaintext(true).build();
   }
-  
+
   private void initializeMessageExchange() {
     try {
       tryInitializeMessageExchange();
@@ -115,6 +115,11 @@ class MessageService extends MessageServiceGrpc.MessageServiceImplBase {
 
   @Override
   public void createChat(CreateChatRequest req, StreamObserver<CreateChatResponse> responseObserver) {
+    if (req.getTitle() == null || req.getTitle().length() == 0) {
+      responseObserver.onError(new Exception("Title is empty or missing"));
+      responseObserver.onCompleted();
+    }
+
     ChatEntity.Builder chatBuilder = new ChatEntity.Builder();
     chatBuilder.setId(null);
     chatBuilder.setTitle(req.getTitle());

--- a/restapi/src/main/java/sjchat/restapi/controllers/ChatController.java
+++ b/restapi/src/main/java/sjchat/restapi/controllers/ChatController.java
@@ -30,6 +30,7 @@ import sjchat.messages.UpdateChatRequest;
 import sjchat.messages.UpdateChatResponse;
 import sjchat.restapi.entities.Chat;
 import sjchat.restapi.entities.ChatRequest;
+import sjchat.restapi.entities.ErrorResponse;
 import sjchat.restapi.entities.Message;
 import sjchat.restapi.entities.User;
 import sjchat.users.CreateUserRequest;
@@ -121,8 +122,12 @@ public class ChatController {
           produces = "application/json",
           consumes = "application/json")
   @ResponseBody
-  public ResponseEntity<Chat> createChat(@RequestBody ChatRequest chatRequest) {
+  public ResponseEntity<Object> createChat(@RequestBody ChatRequest chatRequest) {
     final MessageServiceGrpc.MessageServiceBlockingStub blockingStub = MessageServiceGrpc.newBlockingStub(messageServiceChannel);
+
+    if (chatRequest.getTitle() == null || chatRequest.getTitle().length() == 0) {
+      return new ResponseEntity<>(new ErrorResponse("Empty of missing title"), HttpStatus.BAD_REQUEST);
+    }
 
     CreateChatRequest.Builder chatDataRequestBuilder = CreateChatRequest.newBuilder();
     chatDataRequestBuilder.setTitle(chatRequest.getTitle());
@@ -157,8 +162,12 @@ public class ChatController {
           produces = "application/json",
           consumes = "application/json")
   @ResponseBody
-  public ResponseEntity<Chat> updateChat(@PathVariable String chatId, @RequestBody ChatRequest chatRequest) {
+  public ResponseEntity<Object> updateChat(@PathVariable String chatId, @RequestBody ChatRequest chatRequest) {
     final MessageServiceGrpc.MessageServiceBlockingStub blockingStub = MessageServiceGrpc.newBlockingStub(messageServiceChannel);
+
+    if (chatRequest.getTitle() == null || chatRequest.getTitle().length() == 0) {
+      return new ResponseEntity<>(new ErrorResponse("Empty of missing title"), HttpStatus.BAD_REQUEST);
+    }
 
     UpdateChatRequest.Builder chatDataRequestBuilder = UpdateChatRequest.newBuilder();
     chatDataRequestBuilder.setId(chatId);

--- a/restapi/src/main/java/sjchat/restapi/entities/ErrorResponse.java
+++ b/restapi/src/main/java/sjchat/restapi/entities/ErrorResponse.java
@@ -1,0 +1,17 @@
+package sjchat.restapi.entities;
+
+public class ErrorResponse {
+  private String message;
+
+  public ErrorResponse(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}


### PR DESCRIPTION
### Issues: #105

### Test Plan
Tested to create and update chats with empty title in the REST API. The API now returns an error message.

### Description
It is no longer possible to create or update chats with empty titles. Both the REST API and message service validates this.