### PR TITLE
Log everything to google cloud compute

### DIFF
--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -24,6 +24,8 @@ services:
         max_attempts: 3
     ports:
       - "8080:8080"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -44,6 +46,8 @@ services:
         max_attempts: 3
     ports:
       - "50052:50052"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -59,6 +63,8 @@ services:
         constraints: [node.role == manager]
     ports:
       - "27017:27017"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
 
@@ -75,6 +81,8 @@ services:
         max_attempts: 3
     ports:
       - "50051:50051"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -86,6 +94,8 @@ services:
       replicas: 2
     ports:
       - "8082:80"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
 

--- a/docker-compose-staging.yaml
+++ b/docker-compose-staging.yaml
@@ -24,6 +24,8 @@ services:
         max_attempts: 3
     ports:
       - "8080:8080"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -44,6 +46,8 @@ services:
         max_attempts: 3
     ports:
       - "50052:50052"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -59,6 +63,8 @@ services:
         constraints: [node.role == manager]
     ports:
       - "27017:27017"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
 
@@ -75,6 +81,8 @@ services:
         max_attempts: 3
     ports:
       - "50051:50051"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
     depends_on:
@@ -84,6 +92,8 @@ services:
     image: sjchat/sjchat-web-client
     ports:
       - "8082:80"
+    logging:
+      driver: gcplogs
     networks:
       - webnet
 


### PR DESCRIPTION
### Issues: #72 

### Test Plan
I tested that the google cloud logging driver works by running 
```
sudo docker service update --log-driver=gcplogs sjchat_restapi sjchat_restapi
sudo docker service update --log-driver=gcplogs sjchat_user-service sjchat_user-service
sudo docker service update --log-driver=gcplogs sjchat_message-service sjchat_message-service
sudo docker service update --log-driver=gcplogs sjchat_web-client sjchat_web-client
sudo docker service update --log-driver=gcplogs sjchat_database sjchat_database
```

The docker config commands are taken from https://docs.docker.com/compose/compose-file/#logging so I think they will work.

### Description

Aggregate all our logs to the google clouds logging service. This PR will change the driver from the default json driver to google cloud. So **all logs will now only exist on google clouds logging service**. No logs will be saved at the VMs/docker images.

The logging solutions is far from perfect though. Because the google-logging-docker driver create one log entry for each line in stdin/sterr. The driver also lose all information about the log level (error/warning/info/etc). It's also hard to filter the logs to only show Java exceptions or all HTTP requests.

But I think this solutions is better than only having the logs on each separate machine.