### PR TITLE
Added createdAt for Messages

### DIFF
--- a/database-service/src/main/java/sjchat/entities/MessageEntity.java
+++ b/database-service/src/main/java/sjchat/entities/MessageEntity.java
@@ -17,13 +17,16 @@ public class MessageEntity {
     private String message;
     @Column(name="sender")
     private String sender;
+    @Column(name="created_at")
+    private long createdAt;
 
     public MessageEntity(){}
-    public MessageEntity(String id, String chatid, String message, String sender){
+    public MessageEntity(String id, String chatid, String message, String sender, long createdAt){
         this.id = id;
         this.chatid = chatid;
         this.message = message;
         this.sender = sender;
+        this.createdAt = createdAt;
     }
 
     public String getMessage(){
@@ -37,5 +40,8 @@ public class MessageEntity {
     }
     public String getId(){
         return id;
+    }
+    public long getCreatedAt(){
+        return createdAt;
     }
 }

--- a/message-service/src/main/java/sjchat/messages/MessageService.java
+++ b/message-service/src/main/java/sjchat/messages/MessageService.java
@@ -43,31 +43,6 @@ class MessageService extends MessageServiceGrpc.MessageServiceImplBase {
     return ManagedChannelBuilder.forAddress(host, 50051).usePlaintext(true).build();
   }
 
-  private static Chat.Builder buildMockChat(String id) {
-    Random random = new Random();
-    Chat.Builder chatBuilder = Chat.newBuilder();
-    chatBuilder.setId("mock-id");
-    chatBuilder.setTitle("Test chat " + chatBuilder.getId());
-    return chatBuilder;
-  }
-
-  private static User.Builder buildMockUser() {
-    Random random = new Random();
-    User.Builder userBuilder = User.newBuilder();
-    userBuilder.setId("mock-id");
-    userBuilder.setUsername("user_" + userBuilder.getId());
-    return userBuilder;
-  }
-
-  private static Message.Builder buildMockMessage() {
-    Random random = new Random();
-    Message.Builder messageBuilder = Message.newBuilder();
-    messageBuilder.setId("mock-id");
-    messageBuilder.setMessage("Test message " + messageBuilder.getId());
-    messageBuilder.setSender("id");
-    return messageBuilder;
-  }
-
   private void initializeMessageExchange() {
     try {
       tryInitializeMessageExchange();

--- a/proto/message-service.proto
+++ b/proto/message-service.proto
@@ -80,4 +80,5 @@ message Message {
     string message = 2;
     string sender = 3;
     string chat = 4;
+    int64 createdAt = 5;
 }

--- a/rest-api-0_1_2-swagger.yaml
+++ b/rest-api-0_1_2-swagger.yaml
@@ -109,7 +109,7 @@ paths:
       produces:
         - application/json
       description: |
-        Gets a list of `Message` objects in the given chat.
+        Gets a list of `Message` objects in the given chat. Sorted by createdAt in ascending order.
       parameters:
         - name: chatId
           in: path
@@ -265,6 +265,8 @@ definitions:
       message:
         type: string
       sender:
+        type: integer
+      createdAt:
         type: integer
   NewMessage:
     type: object

--- a/restapi/src/main/java/sjchat/restapi/controllers/ChatController.java
+++ b/restapi/src/main/java/sjchat/restapi/controllers/ChatController.java
@@ -84,7 +84,7 @@ public class ChatController {
     message.setId(responseMessage.getId());
     message.setMessage(responseMessage.getMessage());
     message.setUser(responseMessage.getSender());
-
+    message.setCreatedAt(responseMessage.getCreatedAt());
     return message;
   }
 

--- a/restapi/src/main/java/sjchat/restapi/entities/Message.java
+++ b/restapi/src/main/java/sjchat/restapi/entities/Message.java
@@ -5,6 +5,7 @@ public class Message {
   private String id;
   private String message;
   private String sender;
+  private long createdAt;
 
   public Message() {
   }
@@ -37,5 +38,13 @@ public class Message {
 
   public void setUser(String user) {
     this.sender = user;
+  }
+
+  public long getCreatedAt(){
+    return createdAt;
+  }
+
+  public void setCreatedAt(long createdAt){
+    this.createdAt = createdAt;
   }
 }


### PR DESCRIPTION
### Issues: #84 

### Test Plan
Tested the concerned API endpoints and verified that they were correctly given a timestamp by the server and were sorted.
 
### Description
Adds a timestamp to messages. This to prevent it from being possible to have messages appear randomly in the middle of the chat.
The server is in charge of adding the timestamp to prevent tampering.
The server also sorts the messages in ascending order.